### PR TITLE
fix: serialize null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v0.2.3
+
+## Fixed
+- serialize null values ([commit](https://github.com/clightning4j/JRPClightning/commit/f00561fd23b7120fce7b689c8ebfa07ec2996d9e)). @vincenzopalazzo 13-01-2023

--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,16 @@
+{
+  "package_name": "JRPClightning",
+  "version": "v0.2.3",
+  "api": {
+    "name": "github",
+    "repository": "clightning4j/JRPClightning",
+    "branch": "macros/serialize-null"
+  },
+  "generation_method": {
+    "name": "semver-v2",
+    "header_filter": false
+  },
+  "serialization_method": {
+    "name": "md"
+  }
+}

--- a/src/main/java/jrpc/service/converters/JsonConverter.java
+++ b/src/main/java/jrpc/service/converters/JsonConverter.java
@@ -56,7 +56,7 @@ public class JsonConverter implements IConverter {
         CLightningFeeRate.class, new FeeRateTypeAdapter(gsonBuilder.create()));
     gsonBuilder.registerTypeAdapter(
         BitcoinUTXO.class, new BitcoinUTXOTypeAdapter(gsonBuilder.create()));
-    this.gson = gsonBuilder.create();
+    this.gson = gsonBuilder.serializeNulls().create();
   }
 
   @Override


### PR DESCRIPTION
The GSon library does not include by
default the null values, but this
can be needed in some plugin like
btcj4cli.

lets see what the CI is tell me

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>