### PR TITLE
fix(channel): `feerange` param in close command

### DIFF
--- a/src/main/java/jrpc/clightning/rpc/channel/CLightningChannelRPC.java
+++ b/src/main/java/jrpc/clightning/rpc/channel/CLightningChannelRPC.java
@@ -21,13 +21,13 @@ public class CLightningChannelRPC {
       String feeNegotiationStep,
       String wrongFunding,
       boolean forceLeaseClosed,
-      List<Number> feeange) {
+      List<Number> feeRange) {
     ParameterChecker.doCheckString("close", "id", id, false);
     ParameterChecker.doCheckString("close", "destination", destination, true);
     ParameterChecker.doCheckString("close", "unilateralTimeout", unilateralTimeout, true);
     ParameterChecker.doCheckString("close", "feeNegotiationStep", feeNegotiationStep, true);
     ParameterChecker.doCheckString("close", "wrongFunding", wrongFunding, true);
-    ParameterChecker.doCheckObjectNotNull("close", "feeange", feeange);
+    ParameterChecker.doCheckObjectNotNull("close", "feeRange", feeRange);
 
     HashMap<String, Object> payload = new HashMap<>();
     payload.put("id", id.trim());
@@ -47,7 +47,7 @@ public class CLightningChannelRPC {
     }
 
     payload.put("force_lease_closed", forceLeaseClosed);
-    payload.put("feeange", feeange);
+    payload.put("feerange", feeRange);
     return (CLightningClose) mediatorCommand.runCommand(Command.CLOSE, payload);
   }
 


### PR DESCRIPTION
Currently evaluating if this library can be used as default client for cln nodes in https://github.com/theborakompanioni/bitcoin-spring-boot-starter .

Still testing and evaluating, but noticed that according to https://lightning.readthedocs.io/lightning-close.7.html, a param in the channel close command is called `feerange`, not `feeange`. I have not yet done any integration tests, so please excuse me if I am mistaken.

