### PR TITLE
build(deps): update reflections from v0.9.12 to v0.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.kohlschutter.junixsocket:junixsocket-native-common:2.4.0'
 
     implementation 'com.google.code.gson:gson:2.8.8'
-    implementation 'org.reflections:reflections:0.9.12'
+    implementation 'org.reflections:reflections:0.10.2'
     implementation 'com.google.guava:guava:31.0.1-jre'
 
     implementation 'commons-io:commons-io:2.4'


### PR DESCRIPTION
This PR updated dependency `org.reflections:reflections` from `v0.9.12` to `v0.10.2`

Ran in to the following issue: https://github.com/ronmamo/reflections/issues/297
This seems to have been fixed with newer version (>=`v0.10.0`) of `org.reflections:reflections`.

```
Caused by: org.reflections.ReflectionsException: Scanner FieldAnnotationsScanner was not configured
	at org.reflections.Store.get(Store.java:39)
	at org.reflections.Store.get(Store.java:61)
	at org.reflections.Store.get(Store.java:46)
	at org.reflections.Reflections.getFieldsAnnotatedWith(Reflections.java:546)
	at jrpc.clightning.plugins.CLightningPlugin.addOptionsWithAnnotation(CLightningPlugin.java:305)
	at jrpc.clightning.plugins.CLightningPlugin.registerMethod(CLightningPlugin.java:298)
	at jrpc.clightning.plugins.CLightningPlugin.start(CLightningPlugin.java:115)
	at org.tbk.example.ExamplePlugin.start(ExamplePlugin.java:14)
```