### PR TITLE
build(deps): expose gson dependency transitively 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.kohlschutter.junixsocket:junixsocket-common:2.4.0'
     implementation 'com.kohlschutter.junixsocket:junixsocket-native-common:2.4.0'
 
-    implementation 'com.google.code.gson:gson:2.8.8'
+    api 'com.google.code.gson:gson:2.8.8'
     implementation 'org.reflections:reflections:0.10.2'
     implementation 'com.google.guava:guava:31.0.1-jre'
 

--- a/src/main/java/jrpc/service/converters/JsonConverter.java
+++ b/src/main/java/jrpc/service/converters/JsonConverter.java
@@ -35,7 +35,7 @@ public class JsonConverter implements IConverter {
 
   private static final String ENCODING_DEFAULT = "UTF-8";
 
-  private String patternFormat = "dd-MM-yyyy HH:mm:ss";
+  private final String patternFormat = "dd-MM-yyyy HH:mm:ss";
 
   private final GsonBuilder gsonBuilder;
   private final Gson gson;
@@ -102,7 +102,7 @@ public class JsonConverter implements IConverter {
     return response;
   }
 
-  protected class MyDateTypeAdapter extends TypeAdapter<Date> {
+  protected static class MyDateTypeAdapter extends TypeAdapter<Date> {
     @Override
     public void write(JsonWriter out, Date value) throws IOException {
       if (value == null) {

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
@@ -5,14 +5,18 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Objects;
+
 import jrpc.clightning.model.types.bitcoin.BitcoinDestination;
+
+import static java.util.Objects.requireNonNull;
 
 public class BitcoinOutputTypeAdapter extends TypeAdapter<BitcoinDestination> {
 
   private final Gson gson;
 
   public BitcoinOutputTypeAdapter(Gson gson) {
-    this.gson = gson;
+    this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
@@ -1,15 +1,13 @@
 package jrpc.service.converters.jsontypeadapter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Objects;
-
 import jrpc.clightning.model.types.bitcoin.BitcoinDestination;
-
-import static java.util.Objects.requireNonNull;
 
 public class BitcoinOutputTypeAdapter extends TypeAdapter<BitcoinDestination> {
 

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinOutputTypeAdapter.java
@@ -9,7 +9,7 @@ import jrpc.clightning.model.types.bitcoin.BitcoinDestination;
 
 public class BitcoinOutputTypeAdapter extends TypeAdapter<BitcoinDestination> {
 
-  private Gson gson;
+  private final Gson gson;
 
   public BitcoinOutputTypeAdapter(Gson gson) {
     this.gson = gson;

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
@@ -7,12 +7,14 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import jrpc.clightning.model.types.bitcoin.BitcoinUTXO;
 
+import static java.util.Objects.requireNonNull;
+
 public class BitcoinUTXOTypeAdapter extends TypeAdapter<BitcoinUTXO> {
 
   private final Gson gson;
 
   public BitcoinUTXOTypeAdapter(Gson gson) {
-    this.gson = gson;
+      this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
@@ -9,7 +9,7 @@ import jrpc.clightning.model.types.bitcoin.BitcoinUTXO;
 
 public class BitcoinUTXOTypeAdapter extends TypeAdapter<BitcoinUTXO> {
 
-  private Gson gson;
+  private final Gson gson;
 
   public BitcoinUTXOTypeAdapter(Gson gson) {
     this.gson = gson;

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/BitcoinUTXOTypeAdapter.java
@@ -1,5 +1,7 @@
 package jrpc.service.converters.jsontypeadapter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -7,14 +9,12 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import jrpc.clightning.model.types.bitcoin.BitcoinUTXO;
 
-import static java.util.Objects.requireNonNull;
-
 public class BitcoinUTXOTypeAdapter extends TypeAdapter<BitcoinUTXO> {
 
   private final Gson gson;
 
   public BitcoinUTXOTypeAdapter(Gson gson) {
-      this.gson = requireNonNull(gson);
+    this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
@@ -10,12 +10,14 @@ import jrpc.clightning.model.CLightningFeeRate;
 import jrpc.clightning.model.types.FeeRateInfo;
 import jrpc.clightning.model.types.OnChainFeeEstimates;
 
+import static java.util.Objects.requireNonNull;
+
 public class FeeRateTypeAdapter extends TypeAdapter<CLightningFeeRate> {
 
   private final Gson gson;
 
   public FeeRateTypeAdapter(Gson gson) {
-    this.gson = gson;
+      this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
@@ -1,5 +1,7 @@
 package jrpc.service.converters.jsontypeadapter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -10,14 +12,12 @@ import jrpc.clightning.model.CLightningFeeRate;
 import jrpc.clightning.model.types.FeeRateInfo;
 import jrpc.clightning.model.types.OnChainFeeEstimates;
 
-import static java.util.Objects.requireNonNull;
-
 public class FeeRateTypeAdapter extends TypeAdapter<CLightningFeeRate> {
 
   private final Gson gson;
 
   public FeeRateTypeAdapter(Gson gson) {
-      this.gson = requireNonNull(gson);
+    this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/FeeRateTypeAdapter.java
@@ -12,7 +12,7 @@ import jrpc.clightning.model.types.OnChainFeeEstimates;
 
 public class FeeRateTypeAdapter extends TypeAdapter<CLightningFeeRate> {
 
-  private Gson gson;
+  private final Gson gson;
 
   public FeeRateTypeAdapter(Gson gson) {
     this.gson = gson;

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
@@ -1,5 +1,7 @@
 package jrpc.service.converters.jsontypeadapter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -7,14 +9,12 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import jrpc.clightning.plugins.rpcmethods.init.InitMethod;
 
-import static java.util.Objects.requireNonNull;
-
 public class InitMethodTypeAdapter extends TypeAdapter<InitMethod> {
 
   private final Gson gson;
 
   public InitMethodTypeAdapter(Gson gson) {
-      this.gson = requireNonNull(gson);
+    this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
@@ -9,7 +9,7 @@ import jrpc.clightning.plugins.rpcmethods.init.InitMethod;
 
 public class InitMethodTypeAdapter extends TypeAdapter<InitMethod> {
 
-  private Gson gson;
+  private final Gson gson;
 
   public InitMethodTypeAdapter(Gson gson) {
     this.gson = gson;

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/InitMethodTypeAdapter.java
@@ -7,12 +7,14 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import jrpc.clightning.plugins.rpcmethods.init.InitMethod;
 
+import static java.util.Objects.requireNonNull;
+
 public class InitMethodTypeAdapter extends TypeAdapter<InitMethod> {
 
   private final Gson gson;
 
   public InitMethodTypeAdapter(Gson gson) {
-    this.gson = gson;
+      this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
@@ -16,6 +16,8 @@
  */
 package jrpc.service.converters.jsontypeadapter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -27,15 +29,13 @@ import jrpc.clightning.plugins.rpcmethods.manifest.ManifestMethod;
 import jrpc.clightning.plugins.rpcmethods.manifest.types.Features;
 import jrpc.clightning.plugins.rpcmethods.manifest.types.Option;
 
-import static java.util.Objects.requireNonNull;
-
 /** @author https://github.com/vincenzopalazzo */
 public class ManifestMethodTypeAdapter extends TypeAdapter<ManifestMethod> {
 
   private final Gson gson;
 
   public ManifestMethodTypeAdapter(Gson gson) {
-      this.gson = requireNonNull(gson);
+    this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
@@ -30,7 +30,7 @@ import jrpc.clightning.plugins.rpcmethods.manifest.types.Option;
 /** @author https://github.com/vincenzopalazzo */
 public class ManifestMethodTypeAdapter extends TypeAdapter<ManifestMethod> {
 
-  private Gson gson;
+  private final Gson gson;
 
   public ManifestMethodTypeAdapter(Gson gson) {
     this.gson = gson;

--- a/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
+++ b/src/main/java/jrpc/service/converters/jsontypeadapter/ManifestMethodTypeAdapter.java
@@ -27,13 +27,15 @@ import jrpc.clightning.plugins.rpcmethods.manifest.ManifestMethod;
 import jrpc.clightning.plugins.rpcmethods.manifest.types.Features;
 import jrpc.clightning.plugins.rpcmethods.manifest.types.Option;
 
+import static java.util.Objects.requireNonNull;
+
 /** @author https://github.com/vincenzopalazzo */
 public class ManifestMethodTypeAdapter extends TypeAdapter<ManifestMethod> {
 
   private final Gson gson;
 
   public ManifestMethodTypeAdapter(Gson gson) {
-    this.gson = gson;
+      this.gson = requireNonNull(gson);
   }
 
   @Override

--- a/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
+++ b/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
@@ -1,12 +1,12 @@
 package jrpc.service.converters.jsonwrapper;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.gson.*;
 import java.util.Map;
 import java.util.Set;
 import jrpc.service.CLightningLogger;
 import jrpc.service.converters.JsonConverter;
-
-import static java.util.Objects.requireNonNull;
 
 public class CLightningJsonObject extends JsonElement {
 

--- a/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
+++ b/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
@@ -6,6 +6,8 @@ import java.util.Set;
 import jrpc.service.CLightningLogger;
 import jrpc.service.converters.JsonConverter;
 
+import static java.util.Objects.requireNonNull;
+
 public class CLightningJsonObject extends JsonElement {
 
   private static final Class<CLightningJsonObject> TAG = CLightningJsonObject.class;
@@ -13,13 +15,12 @@ public class CLightningJsonObject extends JsonElement {
   private final JsonObject jsonObject;
   private final JsonConverter converter;
 
-  public CLightningJsonObject(JsonObject jsonObject) {
-    this.jsonObject = jsonObject;
-    this.converter = new JsonConverter();
+  public CLightningJsonObject() {
+    this(new JsonObject());
   }
 
-  public CLightningJsonObject() {
-    this.jsonObject = new JsonObject();
+  public CLightningJsonObject(JsonObject jsonObject) {
+    this.jsonObject = requireNonNull(jsonObject);
     this.converter = new JsonConverter();
   }
 

--- a/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
+++ b/src/main/java/jrpc/service/converters/jsonwrapper/CLightningJsonObject.java
@@ -8,10 +8,10 @@ import jrpc.service.converters.JsonConverter;
 
 public class CLightningJsonObject extends JsonElement {
 
-  private static final Class TAG = CLightningJsonObject.class;
+  private static final Class<CLightningJsonObject> TAG = CLightningJsonObject.class;
 
-  private JsonObject jsonObject;
-  private JsonConverter converter;
+  private final JsonObject jsonObject;
+  private final JsonConverter converter;
 
   public CLightningJsonObject(JsonObject jsonObject) {
     this.jsonObject = jsonObject;


### PR DESCRIPTION
Since `gson` is part of the API (e.g. in `jrpc.service.converters.jsonwrapper.CLightningJsonObject#getAsJsonObject`) it should be transitively exposed to all downstream consumers. Otherwise such libs would all have to define a dependency to gson manually.

Small cleanup included, e.g. check for null values at first possible chance, final fields, etc.